### PR TITLE
Multi process

### DIFF
--- a/api/doc/swagger.yml
+++ b/api/doc/swagger.yml
@@ -128,7 +128,7 @@ paths:
        '200':
          description: OK
   '/projects':
-   get:
+    get:
      tags:
        - projects
      summary: "Récupération de tous les projets"
@@ -149,7 +149,7 @@ paths:
     put:
       tags:
         - clusters
-      summary: "Insetion d'un cluster dans la base"
+      summary: "Insertion d'un cluster dans la base"
       description: "Insertion d'un client en précisant le nom de la machine"
       parameters: 
         - in: query
@@ -158,6 +158,22 @@ paths:
           required: true
           schema:
             type: string
+      responses:
+        '200':
+          description: OK
+  '/cluster/unavailable':
+    post:
+      tags:
+        - clusters
+      summary: "Mise a jour d'un client"
+      description: "Mise a jour d'un client pour signaler qu'il n'est plus actif"
+      parameters:
+        - in: query
+          name: id
+          description: id de la ressource
+          required: true
+          schema:
+            type: integer
       responses:
         '200':
           description: OK

--- a/api/middlewares/cluster.js
+++ b/api/middlewares/cluster.js
@@ -1,4 +1,5 @@
 const { matchedData } = require('express-validator/filter');
+const debug = require('debug')('job');
 
 async function getAllClusters(req, res, next) {
   await req.client.query('SELECT * FROM cluster')
@@ -19,8 +20,18 @@ async function insertCluster(req, res, next) {
 
   const { host } = params;
 
-  await req.client.query(
-    'INSERT INTO cluster (host, id_thread, active, available) VALUES ( $1 , (select count(id) from cluster where host = $2), true, true ) RETURNING id',
+  await req.pgPool.query(
+    'LOCK TABLE cluster IN EXCLUSIVE MODE',
+  )
+    .catch((error) => {
+      req.error = {
+        msg: error.toString(),
+        code: 500,
+        function: 'insertCluster',
+      };
+    });
+  await req.pgPool.query(
+    'INSERT INTO cluster (host, id_thread, active, available) VALUES ( $1 , (select count(id) from cluster where host = $2 AND available = \'True\'), true, true ) RETURNING id',
     [host, host],
   )
     .then((results) => { req.result = results.rows; })
@@ -34,7 +45,23 @@ async function insertCluster(req, res, next) {
   next();
 }
 
+async function unavailableCluster(req, res, next) {
+  const params = matchedData(req);
+  const { id } = params;
+  debug('update ', id);
+  await req.pgPool.query('UPDATE cluster SET available=\'False\' WHERE id=$1', [id])
+    .catch((error) => {
+      req.error = {
+        msg: error.toString(),
+        code: 500,
+        function: 'updateCluster',
+      };
+    });
+  next();
+}
+
 module.exports = {
   getAllClusters,
   insertCluster,
+  unavailableCluster,
 };

--- a/api/middlewares/cluster.js
+++ b/api/middlewares/cluster.js
@@ -20,7 +20,7 @@ async function insertCluster(req, res, next) {
 
   const { host } = params;
 
-  await req.pgPool.query(
+  await req.client.query(
     'LOCK TABLE cluster IN EXCLUSIVE MODE',
   )
     .catch((error) => {
@@ -30,7 +30,7 @@ async function insertCluster(req, res, next) {
         function: 'insertCluster',
       };
     });
-  await req.pgPool.query(
+  await req.client.query(
     'INSERT INTO cluster (host, id_thread, active, available) VALUES ( $1 , (select count(id) from cluster where host = $2 AND available = \'True\'), true, true ) RETURNING id',
     [host, host],
   )
@@ -49,7 +49,7 @@ async function unavailableCluster(req, res, next) {
   const params = matchedData(req);
   const { id } = params;
   debug('update ', id);
-  await req.pgPool.query('UPDATE cluster SET available=\'False\' WHERE id=$1', [id])
+  await req.client.query('UPDATE cluster SET available=\'False\' WHERE id=$1', [id])
     .catch((error) => {
       req.error = {
         msg: error.toString(),

--- a/api/middlewares/jobs.js
+++ b/api/middlewares/jobs.js
@@ -36,12 +36,12 @@ async function updateJobStatus(req, res, next) {
   const params = matchedData(req);
   const { id } = params;
   const { status } = params;
-  const { returnCode } = params;
+  const returnCode = params.return_code;
   const { log } = params;
 
   debug(`id = ${id}`);
   debug(`status = ${status}`);
-  debug(`return_code = ${returnCode}`);
+  debug(`returnCode = ${returnCode}`);
   debug(`log = ${log}`);
 
   await req.client.query(

--- a/api/middlewares/jobs.js
+++ b/api/middlewares/jobs.js
@@ -37,7 +37,7 @@ async function updateJobStatus(req, res, next) {
   const params = matchedData(req);
   const { id } = params;
   const { status } = params;
-  const returnCode = params.return_code;
+  const { returnCode } = params;
   const { log } = params;
 
   debug(`id = ${id}`);

--- a/api/middlewares/jobs.js
+++ b/api/middlewares/jobs.js
@@ -18,17 +18,18 @@ async function getJobReady(req, res, next) {
   const params = matchedData(req);
 
   const id = params.id_cluster;
-  await req.client.query(
-    "UPDATE jobs SET status = 'running', start_date=NOW(), id_cluster = $1 WHERE id = (SELECT id FROM jobs WHERE status = 'ready' LIMIT 1) RETURNING id, command", [id],
-  )
-    .then((results) => { req.result = results.rows; })
-    .catch((error) => {
-      req.error = {
-        msg: error.toString(),
-        code: 500,
-        function: 'getJobReady',
-      };
-    });
+  try {
+    await req.client.query('LOCK TABLE cluster IN EXCLUSIVE MODE');
+    await req.client.query(
+      "UPDATE jobs SET status = 'running', start_date=NOW(), id_cluster = $1 WHERE id = (SELECT id FROM jobs WHERE status = 'ready' LIMIT 1) RETURNING id, command", [id],
+    ).then((results) => { req.result = results.rows; });
+  } catch (error) {
+    req.error = {
+      msg: error.toString(),
+      code: 500,
+      function: 'getJobReady',
+    };
+  }
   next();
 }
 

--- a/api/routes/cluster/index.js
+++ b/api/routes/cluster/index.js
@@ -24,4 +24,16 @@ clusters.insertCluster,
 pgClient.close,
 returnMsg);
 
+router.post('/cluster/unavailable', [
+  query('id')
+    .exists().withMessage(createErrorMsg.getMissingParameterMsg('id'))
+    .isInt({ min: 1 })
+    .withMessage(createErrorMsg.getInvalidParameterMsg('id')),
+],
+validateParams,
+pgClient.open,
+clusters.unavailableCluster,
+pgClient.close,
+returnMsg);
+
 module.exports = router;

--- a/client/client.py
+++ b/client/client.py
@@ -20,7 +20,7 @@ def init_worker():
 
 def process(id):
     strId = "["+str(id)+"] : "
-    print(strId, " : begin")
+    print(strId, "begin")
     id_cluster = -1
 
     def signal_handler(sig, frame):
@@ -31,12 +31,12 @@ def process(id):
     
     Ok = True
 
-    req=requests.put('http://'+UrlApi+':8080/api/cluster/'+HostName)
+    req=requests.put('http://'+UrlApi+':8080/api/cluster?host='+HostName)
     id_cluster = req.json()[0]['id']
     print(strId, "id_cluster = ", str(id_cluster))
     while Ok:
         print(strId, Ok)
-        req=requests.get('http://'+UrlApi+':8080/api/job/ready/'+str(id_cluster))
+        req=requests.get('http://'+UrlApi+':8080/api/job/ready?id_cluster='+str(id_cluster))
         if(len(req.json())!=0):
             id_job = req.json()[0]['id']
             command = req.json()[0]['command']

--- a/client/start.sh
+++ b/client/start.sh
@@ -3,4 +3,4 @@ if [ "$(docker ps -aq -f name=client-gpao)" ]; then
     docker rm -f client-gpao
 fi
 
-python client.py
+python3 client.py


### PR DESCRIPTION
Gestion Multi Process:

- ajout d'une route pour signaler qu'une ressource n'est plus active (cluster/unavailable)
- dans le client python:
  - création d'autant de sous processus que de coeurs dispo sur la machine (il faudra rendre ça paramètrable)
  - création d'un dossier temporaire pour chaque sous processus, ce dossier devient le dossier d'exécution des commandes, il est automatiquement détruit lorsque l'on arrête le client
  - gestion des signaux pour arrêter proprement les sous processus lorsque l'on reçoit un Ctr+C
- on force l'utilisation de python3 dans le script start.sh du client
- ~un petit fix sur le returnCode des jobs~ (déjà corrigé dans le master)

Il restera à faire: une refonte de la notion de cluster. Finalement, je crois qu'il s'agit plutôt d'une table des sessions. Pour chaque sessions, on a déjà:

- le hostname
- un numéro de thread

on pourrait ajouter (à discuter):

- date de début de la session
- date de la fin de la session
- working directory 