### PR TITLE
gestion de l'espace disque min

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -14,6 +14,7 @@ import tempfile
 HostName=socket.gethostname()
 NbProcess = multiprocessing.cpu_count()
 UrlApi = os.getenv('URL_API', 'localhost')
+minAvailableSpace = 10
 
 def process(id):
     strId = "["+str(id)+"] : "
@@ -29,8 +30,15 @@ def process(id):
         id_session = req.json()[0]['id']
         print(strId, "id_session = ", str(id_session))
         while True:
-            req=requests.get('http://'+UrlApi+':8080/api/job/ready?id_session='+str(id_session))
-            if(len(req.json())!=0):
+            # on verifie l'espace disponible dans le dossier de travail
+            stat=os.statvfs(working_dir.name)
+            freeGb = int(stat.f_frsize * stat.f_bavail / (1024 * 1024 * 1024))
+            req = None
+            if freeGb < minAvailableSpace:
+                print('espace disque insuffisant pour prendre des traitements : ', freeGb, '/', minAvailableSpace)
+            else:
+                req=requests.get('http://'+UrlApi+':8080/api/job/ready?id_session='+str(id_session))
+            if (req) and (len(req.json())!=0):
                 id_job = req.json()[0]['id']
                 command = req.json()[0]['command']
                 print(strId, "L'identifiant du job "+str(id_job)+" est disponible")


### PR DESCRIPTION
# Motivation
Ne pas prendre de nouveaux jobs si l'espace disque dans le dossier de travail est insuffisant

# Modification
Ajout d'un test avant de la requête de récupération d'un job avec un seuil en dur à 10Gb. Donc, le client ne prendra pas de nouveaux jobs, mais pour le moment il n'en informe pas la GPAO, donc ça n'est pas visible pour le "Monitor". Il faudrait également que le seuil soit ajustable. 
Peut-être même qu'il puisse être spécifié différemment pour un job ou un chantier (mais ça serait beaucoup plus complexe)?