### PR TITLE
fix bug dependances entre jobs

### DIFF
--- a/api/middlewares/project.js
+++ b/api/middlewares/project.js
@@ -106,6 +106,11 @@ async function insertProjectFromJson(req, res, next) {
         await insertProjectDependency(upstream, downstream, req);
       }
     }
+    // Il faut vider le tableau des identifiants de jobs
+    // lorsqu'on insére les jobs du projet suivant
+    // sinon au moment d'insérer les dépendances entre job du projet suivant
+    // il va se baser sur les identifiants du projet précédent
+    req.idJobs = [];
   }
   next();
 }


### PR DESCRIPTION
@yann-ign  m'a remonté un bug lors de l'insertion de plusieurs projet via un fichier Json... 
Les dépendances ne sont pas correctement insérées dans la table jobDependencies lorsqu'il y a plusieurs projets.
Dans l'exemple ci dessus, la dependance  du job 2 du projet 2 fait référence aux identifiants des jobs du projet 1 après insertion.
```
{
  "projects": [
    {
      "name": "Chantier 1",
      "jobs": [
        {
          "name": "jobs 1",
          "command": "touch file1"
        },
        {
          "name": "jobs 2",
          "command": "touch file2"
        },
        {
          "name": "jobs 3",
          "command": "touch file3",
          "deps": [
            {
              "id": 0
            },
            {
              "id": 1
            }
          ]
        }
      ]
    },
    {
      "name": "Chantier 2",
      "jobs": [
        {
          "name": "jobs 1",
          "command": "touch file1"
        },
        {
          "name": "jobs 2",
          "command": "touch file1",
          "deps": [
            {
              "id": 0
            }
          ]
        }
      ],
      "deps": [
        {
          "id": 0
        }
      ]
    }
  ]
}
```

Ce problème est normalement corrigé