### PR TITLE
gestion type int postgres

### DIFF
--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -432,7 +432,7 @@ CREATE TABLE public.jobs (
     end_date timestamp with time zone,
     command character varying NOT NULL,
     status public.status DEFAULT 'ready'::public.status NOT NULL,
-    return_code integer,
+    return_code bigint,
     log character varying,
     id_project integer NOT NULL,
     id_session integer


### PR DESCRIPTION
# Motivation
Actuellement, si une commande retourne un code -1 sous windows, le return_code récupéré par le script client.py est à 4294967295 (valeur max d'un entier long) ce qui dépasse les valeurs supportées par le champs prévu dans Postgres (int). 
La mise à jour du job échoue et cela bloque le script client.
# Correction
Modification du type utilisé dans la BD pour supporter les entiers longs. Attention, il faut bien détruire et reconstruire la BD pour que la modification soit prise en compte.
