### PR TITLE
Interface

### DIFF
--- a/api/middlewares/jobs.js
+++ b/api/middlewares/jobs.js
@@ -2,7 +2,7 @@ const { matchedData } = require('express-validator/filter');
 const debug = require('debug')('job');
 
 async function getAllJobs(req, res, next) {
-  await req.client.query('SELECT * FROM jobs')
+  await req.client.query('SELECT * FROM view_jobs')
     .then((results) => { req.result = results.rows; })
     .catch((error) => {
       req.error = {

--- a/api/middlewares/sessions.js
+++ b/api/middlewares/sessions.js
@@ -2,7 +2,7 @@ const { matchedData } = require('express-validator/filter');
 const debug = require('debug')('session');
 
 async function getAllSessions(req, res, next) {
-  await req.client.query('SELECT * FROM sessions')
+  await req.client.query('SELECT * FROM view_sessions')
     .then((results) => { req.result = results.rows; })
     .catch((error) => {
       req.error = {

--- a/api/test/dependencies.js
+++ b/api/test/dependencies.js
@@ -48,7 +48,7 @@ describe('Dependencies', () => {
             should.equal(err2, null);
             res2.should.have.status(200);
             res2.body.should.be.an('array');
-            idJob = res2.body[0].id;
+            idJob = res2.body[0].job_id;
             done();
           });
       });

--- a/monitor/resources/vendor/ign/gpao.js
+++ b/monitor/resources/vendor/ign/gpao.js
@@ -17,7 +17,7 @@ function deleteProject(id, name) {
 
 // Fonction modifiant le nombre de thrad actif sur une machine
 function setNbThread(host, active) {
-  value = window.prompt(`Modifier le nombre de Threads actifs pour ${host}, ${active}`, 10);
+  value = window.prompt(`Modifier le nombre de Threads actifs pour ${host}, ${active}`, 0);
 
   if (!isNaN(value)) {
     fetch(`${apiUrl}/api/node/setNbActive?host=${host}&limit=${value}`, {

--- a/monitor/routes/index.js
+++ b/monitor/routes/index.js
@@ -33,9 +33,10 @@ router.get('/job/:id', topBar.getInfo, jobs.getJob, dependencies.getDependencies
 });
 
 // jobs page
-router.get('/jobs', topBar.getInfo, jobs.getJobs, (req, res) => {
+router.get('/jobs', topBar.getInfo, jobs.getJobs, projects.getProjects, (req, res) => {
   res.render('pages/jobs', {
     topBar: req.topBar,
+    projects: req.projects,
     jobs: req.jobs,
     api: req.app.get('apiUrl'),
     server: req.app.get('server'),

--- a/monitor/views/partials/components/job_info.ejs
+++ b/monitor/views/partials/components/job_info.ejs
@@ -18,8 +18,8 @@
       <ul class="list-group list-group-flush">
           <li class="list-group-item">Id : <%= job.job_id %></li>
           <li class="list-group-item">Nom du Job : <%= job.job_name %></li>
-          <li class="list-group-item">Date de début : <%= job.date_debut %> à  <%= job.hms_debut %></li>
-          <li class="list-group-item">Date de fin : <%= job.date_fin %> à  <%= job.hms_fin %></li>
+          <li class="list-group-item">Date de début : <%= job.date_debut %> à  <%= job.hms_debut %> (UTC)</li>
+          <li class="list-group-item">Date de fin : <%= job.date_fin %> à  <%= job.hms_fin %> (UTC)</li>
           <li class="list-group-item">Durée : <%= job.duree %> secondes</li>
           <li class="list-group-item">Statut : <%= job.job_status %></li>
           <li class="list-group-item">Code de retour : <%= job.job_return_code %></li>

--- a/monitor/views/partials/components/job_info.ejs
+++ b/monitor/views/partials/components/job_info.ejs
@@ -18,8 +18,9 @@
       <ul class="list-group list-group-flush">
           <li class="list-group-item">Id : <%= job.job_id %></li>
           <li class="list-group-item">Nom du Job : <%= job.job_name %></li>
-          <li class="list-group-item">Date de début : <%= job.job_start_date %></li>
-          <li class="list-group-item">Date de Fin : <%= job.job_end_date %></li>
+          <li class="list-group-item">Date de début : <%= job.date_debut %> à  <%= job.hms_debut %></li>
+          <li class="list-group-item">Date de fin : <%= job.date_fin %> à  <%= job.hms_fin %></li>
+          <li class="list-group-item">Durée : <%= job.duree %> secondes</li>
           <li class="list-group-item">Statut : <%= job.job_status %></li>
           <li class="list-group-item">Code de retour : <%= job.job_return_code %></li>
           <li class="list-group-item">Id Projet : <%= job.project_id %></li>

--- a/monitor/views/partials/head.ejs
+++ b/monitor/views/partials/head.ejs
@@ -43,6 +43,8 @@ $(document).ready(function() {
             }
         },
         "order": [[ 0, "asc" ]],
+        "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "Tous"]],
+        "pageLength": 100,
         "dom": '<"d-flex"<"mr-auto p-2"l<"toolbar_tab">><"p-2"f>>t<"d-flex"<"mr-auto p-2"i><"p-2"p>>',
         "rowCallback": function( row, data, index ) {
             var status = data[2];

--- a/monitor/views/partials/tab/jobs_tab.ejs
+++ b/monitor/views/partials/tab/jobs_tab.ejs
@@ -12,8 +12,9 @@
 				<th>Status</th>
 				<th>Code retour</th>
 				<th>Date début</th>
-				<th>Date fin</th>
-        <th>Id session</th>
+        <th>Heure début</th>
+        <th>Durée en secondes</th>
+        <th>Nom du projet</th>
         <th>Action</th>
 			</tr>
 		</thead>
@@ -24,27 +25,29 @@
 				<th>Status</th>
 				<th>Code retour</th>
 				<th>Date début</th>
-				<th>Date fin</th>
-        <th>Id session</th>
+        <th>Heure début</th>
+        <th>Durée en secondes</th>
+        <th>Nom du projet</th>
         <th>Action</th>
 			</tr>
         </tfoot>
         <tbody>
         <% jobs.forEach(function( job ){ %>
             <tr>
-                <td> <%= job.id %></td>
-                <td> <%= job.name %></td>
-                <td> <%= job.status %></td>
-                <td> <%= job.return_code %></td>
-                <td> <%= job.start_date %></td>
-                <td> <%= job.end_date %></td>
-                <td> <%= job.id_session %></td>
+                <td> <%= job.job_id %></td>
+                <td> <%= job.job_name %></td>
+                <td> <%= job.job_status %></td>
+                <td> <%= job.job_return_code %></td>
+                <td> <%= job.date %></td>
+                <td> <%= job.hms %></td>
+                <td> <%= job.duree %></td>
+                <td> <%= job.project_name %></td>
                 <td>
-                    <button type="button" onclick="location.href='/job/<%= job.id %>'" data-toggle="tooltip" title="Affiche une vue détaillée sur le job <%= job.id %>" class="btn btn-circle btn-success">
+                    <button type="button" onclick="location.href='/job/<%= job.job_id %>'" data-toggle="tooltip" title="Affiche une vue détaillée sur le job <%= job.job_id %>" class="btn btn-circle btn-success">
                         <i class="fas fa-search fa-1x" aria-hidden="true"></i>
                     </button>
                     <%if (job.status == 'failed') { %>
-                      <button type="button" onclick='reinitJobs([<%= job.id %>])' data-toggle="tooltip" title="Réinitialise le job <%= job.id %>" class="btn btn-circle btn-warning">
+                      <button type="button" onclick='reinitJobs([<%= job.job_id %>])' data-toggle="tooltip" title="Réinitialise le job <%= job.job_id %>" class="btn btn-circle btn-warning">
                         <i class="fas fa-sync-alt fa-1x" aria-hidden="true"></i>
                       </button>
                     <%}%>

--- a/monitor/views/partials/tab/jobs_tab.ejs
+++ b/monitor/views/partials/tab/jobs_tab.ejs
@@ -19,7 +19,7 @@
 				<th>Status</th>
 				<th>Code retour</th>
 				<th>Date début</th>
-        <th>Heure début</th>
+        <th>Heure début (UTC)</th>
         <th>Durée (s)</th>
         <th>Id projet</th>
         <th>Nom du projet</th>
@@ -33,7 +33,7 @@
 				<th>Status</th>
 				<th>Code retour</th>
 				<th>Date début</th>
-        <th>Heure début</th>
+        <th>Heure début (UTC)</th>
         <th>Durée (s)</th>
         <th>Id projet</th>
         <th>Nom du projet</th>

--- a/monitor/views/partials/tab/jobs_tab.ejs
+++ b/monitor/views/partials/tab/jobs_tab.ejs
@@ -3,9 +3,16 @@
     <h6 class="m-0 font-weight-bold text-primary">Jobs</h6>
   </div>
   <div class="card-body">
+    <label>Filtrer par projets :</label>
+    <select name="projects" id="project-select">
+        <option value="-1">-- Tous les projets --</option>
+        <% projects.forEach(function( project ){ %>
+          <option value="<%= project.id %>"><%= project.id %> - <%= project.name %></option>
+        <% }) %>
+    </select>
     <div class="table-responsive">
       <table class="table table-bordered table-striped" id="dataTable" cellspacing="0">
-        <thead>
+    <thead>
 			<tr>
         <th>Id</th>
         <th>Nom</th>
@@ -14,6 +21,7 @@
 				<th>Date début</th>
         <th>Heure début</th>
         <th>Durée en secondes</th>
+        <th>Id projet</th>
         <th>Nom du projet</th>
         <th>Action</th>
 			</tr>
@@ -27,6 +35,7 @@
 				<th>Date début</th>
         <th>Heure début</th>
         <th>Durée en secondes</th>
+        <th>Id projet</th>
         <th>Nom du projet</th>
         <th>Action</th>
 			</tr>
@@ -41,6 +50,7 @@
                 <td> <%= job.date %></td>
                 <td> <%= job.hms %></td>
                 <td> <%= job.duree %></td>
+                <td> <%= job.job_id_project %></td>
                 <td> <%= job.project_name %></td>
                 <td>
                     <button type="button" onclick="location.href='/job/<%= job.job_id %>'" data-toggle="tooltip" title="Affiche une vue détaillée sur le job <%= job.job_id %>" class="btn btn-circle btn-success">
@@ -73,5 +83,27 @@
           .append(i)
           .append(' Réinitialiser les jobs en échecs');
     $("div.toolbar_tab").append(button);
+
+
+    var table = $('#dataTable').DataTable();
+     
+    $('#project-select').change( function() {
+        table.draw();
+        //alert("coucou");
+    } );
+
   } );
+
+  $.fn.dataTable.ext.search.push(
+    function( settings, data, dataIndex ) {
+        var project_id = $('#project-select').val()
+        if(project_id == -1){
+          return true;
+        }else if(data[7]==project_id){
+          return true
+        }else{
+          return false
+        }
+    }
+);
 </script>

--- a/monitor/views/partials/tab/jobs_tab.ejs
+++ b/monitor/views/partials/tab/jobs_tab.ejs
@@ -20,7 +20,7 @@
 				<th>Code retour</th>
 				<th>Date début</th>
         <th>Heure début</th>
-        <th>Durée en secondes</th>
+        <th>Durée (s)</th>
         <th>Id projet</th>
         <th>Nom du projet</th>
         <th>Action</th>
@@ -34,7 +34,7 @@
 				<th>Code retour</th>
 				<th>Date début</th>
         <th>Heure début</th>
-        <th>Durée en secondes</th>
+        <th>Durée (s)</th>
         <th>Id projet</th>
         <th>Nom du projet</th>
         <th>Action</th>
@@ -89,7 +89,6 @@
      
     $('#project-select').change( function() {
         table.draw();
-        //alert("coucou");
     } );
 
   } );

--- a/monitor/views/partials/tab/sessions_tab.ejs
+++ b/monitor/views/partials/tab/sessions_tab.ejs
@@ -11,7 +11,9 @@
                 <th>Host</th>
                 <th>Status</th>
                 <th>Date début</th>
+                <th>Heure début (UTC)</th>
                 <th>Date fin</th>
+                <th>Heure fin (UTC)</th>
               </tr>
           </thead>
           <tfoot>
@@ -20,17 +22,21 @@
                 <th>Host</th>
                 <th>Status</th>
                 <th>Date début</th>
+                <th>Heure début (UTC)</th>
                 <th>Date fin</th>
+                <th>Heure fin (UTC)</th>
               </tr>
           </tfoot>
           <tbody>
             <% sessions.forEach(function( session ){ %>
                 <tr>
-                    <td> <%= session.id %></td>
-                    <td> <%= session.host %></td>
-                    <td> <%= session.status %></td>
-                    <td> <%= session.start_date %></td>
-                    <td> <%= session.end_date %></td>
+                    <td> <%= session.sessions_id %></td>
+                    <td> <%= session.sessions_host %></td>
+                    <td> <%= session.sessions_status %></td>
+                    <td> <%= session.date_debut %></td>
+                    <td> <%= session.hms_debut %></td>
+                    <td> <%= session.date_fin %></td>
+                    <td> <%= session.hms_fin %></td>
                 </tr>
             <% }) %>
           </tbody>

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -612,7 +612,12 @@ CREATE VIEW public.view_job AS
     sessions.host AS session_host,
     sessions.start_date AS session_start_date,
     sessions.end_date AS session_end_date,
-    sessions.status AS session_status
+    sessions.status AS session_status,
+    to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date_debut,
+    to_char(jobs.start_date, 'HH:MI:SS'::text) AS hms_debut,
+    ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree,
+    to_char(jobs.end_date, 'DD-MM-YYYY'::text) AS date_fin,
+    to_char(jobs.end_date, 'HH:MI:SS'::text) AS hms_fin
    FROM ((public.jobs
      JOIN public.projects ON ((projects.id = jobs.id_project)))
      LEFT JOIN public.sessions ON ((sessions.id = jobs.id_session)));
@@ -659,6 +664,31 @@ CREATE VIEW public.view_job_status AS
 
 
 ALTER TABLE public.view_job_status OWNER TO postgres;
+
+--
+-- Name: view_jobs; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.view_jobs AS
+ SELECT jobs.id AS job_id,
+    jobs.name AS job_name,
+    jobs.start_date AS job_start_date,
+    jobs.end_date AS job_end_date,
+    jobs.command AS job_command,
+    jobs.status AS job_status,
+    jobs.return_code AS job_return_code,
+    jobs.log AS job_log,
+    jobs.id_project AS job_id_project,
+    jobs.id_session AS job_session,
+    projects.name AS project_name,
+    to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date,
+    to_char(jobs.start_date, 'HH:MI:SS'::text) AS hms,
+    ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree
+   FROM (public.jobs
+     JOIN public.projects ON ((projects.id = jobs.id_project)));
+
+
+ALTER TABLE public.view_jobs OWNER TO postgres;
 
 --
 -- Name: view_project_status; Type: VIEW; Schema: public; Owner: postgres

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -775,6 +775,26 @@ CREATE VIEW public.view_project_status_by_jobs AS
 ALTER TABLE public.view_project_status_by_jobs OWNER TO postgres;
 
 --
+-- Name: view_sessions; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.view_sessions AS
+ SELECT sessions.id AS sessions_id,
+    sessions.host AS sessions_host,
+    sessions.start_date AS sessions_start_date,
+    sessions.end_date AS sessions_end_date,
+    sessions.status AS sessions_status,
+    to_char(sessions.start_date, 'DD-MM-YYYY'::text) AS date_debut,
+    to_char(sessions.start_date, 'HH24:MI:SS'::text) AS hms_debut,
+    ((((((date_part('day'::text, (sessions.end_date - sessions.start_date)) * (24)::double precision) + date_part('hour'::text, (sessions.end_date - sessions.start_date))) * (60)::double precision) + date_part('minute'::text, (sessions.end_date - sessions.start_date))) * (60)::double precision) + (round((date_part('second'::text, (sessions.end_date - sessions.start_date)))::numeric, 2))::double precision) AS duree,
+    to_char(sessions.end_date, 'DD-MM-YYYY'::text) AS date_fin,
+    to_char(sessions.end_date, 'HH24:MI:SS'::text) AS hms_fin
+   FROM public.sessions;
+
+
+ALTER TABLE public.view_sessions OWNER TO postgres;
+
+--
 -- Name: view_sessions_status; Type: VIEW; Schema: public; Owner: postgres
 --
 

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -117,7 +117,7 @@ BEGIN
     WHEN status = 'idle_requested' AND id in (SELECT id FROM sessions WHERE host=hostname AND status <> 'closed' ORDER BY id LIMIT nb_limit) THEN 'running'::session_status
     WHEN status = 'active' AND id not in (SELECT id FROM sessions WHERE host=hostname AND status <> 'closed' ORDER BY id LIMIT nb_limit) THEN 'idle'::session_status
     WHEN status = 'running' AND id not in (SELECT id FROM sessions WHERE host=hostname AND status <> 'closed' ORDER BY id LIMIT nb_limit) THEN 'idle_requested'::session_status
-    ELSE status END) WHERE status <> 'closed';
+    ELSE status END) WHERE status <> 'closed' AND host=hostname;
 END;
 $$;
 
@@ -614,10 +614,10 @@ CREATE VIEW public.view_job AS
     sessions.end_date AS session_end_date,
     sessions.status AS session_status,
     to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date_debut,
-    to_char(jobs.start_date, 'HH24:MI:SS'::text) AS hms_debut,
+    to_char(jobs.start_date::timestamptz at time zone 'UTC', 'HH24:MI:SS'::text) AS hms_debut,
     ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree,
     to_char(jobs.end_date, 'DD-MM-YYYY'::text) AS date_fin,
-    to_char(jobs.end_date, 'HH24:MI:SS'::text) AS hms_fin
+    to_char(jobs.end_date::timestamptz at time zone 'UTC', 'HH24:MI:SS'::text) AS hms_fin
    FROM ((public.jobs
      JOIN public.projects ON ((projects.id = jobs.id_project)))
      LEFT JOIN public.sessions ON ((sessions.id = jobs.id_session)));
@@ -682,7 +682,7 @@ CREATE VIEW public.view_jobs AS
     jobs.id_session AS job_session,
     projects.name AS project_name,
     to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date,
-    to_char(jobs.start_date, 'HH24:MI:SS'::text) AS hms,
+    to_char(jobs.start_date::timestamptz at time zone 'UTC', 'HH24:MI:SS'::text) AS hms,
     ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree
    FROM (public.jobs
      JOIN public.projects ON ((projects.id = jobs.id_project)));
@@ -785,10 +785,10 @@ CREATE VIEW public.view_sessions AS
     sessions.end_date AS sessions_end_date,
     sessions.status AS sessions_status,
     to_char(sessions.start_date, 'DD-MM-YYYY'::text) AS date_debut,
-    to_char(sessions.start_date, 'HH24:MI:SS'::text) AS hms_debut,
+    to_char(sessions.start_date::timestamptz at time zone 'UTC', 'HH24:MI:SS'::text) AS hms_debut,
     ((((((date_part('day'::text, (sessions.end_date - sessions.start_date)) * (24)::double precision) + date_part('hour'::text, (sessions.end_date - sessions.start_date))) * (60)::double precision) + date_part('minute'::text, (sessions.end_date - sessions.start_date))) * (60)::double precision) + (round((date_part('second'::text, (sessions.end_date - sessions.start_date)))::numeric, 2))::double precision) AS duree,
     to_char(sessions.end_date, 'DD-MM-YYYY'::text) AS date_fin,
-    to_char(sessions.end_date, 'HH24:MI:SS'::text) AS hms_fin
+    to_char(sessions.end_date::timestamptz at time zone 'UTC', 'HH24:MI:SS'::text) AS hms_fin
    FROM public.sessions;
 
 

--- a/sql/postgres.sql
+++ b/sql/postgres.sql
@@ -614,10 +614,10 @@ CREATE VIEW public.view_job AS
     sessions.end_date AS session_end_date,
     sessions.status AS session_status,
     to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date_debut,
-    to_char(jobs.start_date, 'HH:MI:SS'::text) AS hms_debut,
+    to_char(jobs.start_date, 'HH24:MI:SS'::text) AS hms_debut,
     ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree,
     to_char(jobs.end_date, 'DD-MM-YYYY'::text) AS date_fin,
-    to_char(jobs.end_date, 'HH:MI:SS'::text) AS hms_fin
+    to_char(jobs.end_date, 'HH24:MI:SS'::text) AS hms_fin
    FROM ((public.jobs
      JOIN public.projects ON ((projects.id = jobs.id_project)))
      LEFT JOIN public.sessions ON ((sessions.id = jobs.id_session)));
@@ -682,7 +682,7 @@ CREATE VIEW public.view_jobs AS
     jobs.id_session AS job_session,
     projects.name AS project_name,
     to_char(jobs.start_date, 'DD-MM-YYYY'::text) AS date,
-    to_char(jobs.start_date, 'HH:MI:SS'::text) AS hms,
+    to_char(jobs.start_date, 'HH24:MI:SS'::text) AS hms,
     ((((((date_part('day'::text, (jobs.end_date - jobs.start_date)) * (24)::double precision) + date_part('hour'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + date_part('minute'::text, (jobs.end_date - jobs.start_date))) * (60)::double precision) + (round((date_part('second'::text, (jobs.end_date - jobs.start_date)))::numeric, 2))::double precision) AS duree
    FROM (public.jobs
      JOIN public.projects ON ((projects.id = jobs.id_project)));


### PR DESCRIPTION
Cette PR traite les sujets suivants : 

* Pb lorsque l'on modifie le nombre de thread sur une machine (Voir ticket interne 1873)
* Amélioration de la visibilité des dates et heures de début de traitement et ajout d'une colonne durée sur la page des jobs et des sessions (Voir ticket interne 1844)
* Ajout d'un filtre sur les projets sur la table des jobs dans la page des jobs (Voir ticket interne 1843)
* Amélioration de la visibilité des dates et heures sur la vue détaillée d'un job
* Passage à 0 au lieu de 10 par défaut du nombre de thread dans la fenêtre de dialogue
* Augmentation du nombre de jobs afficher par défaut à 100 au lieu de 10 (Voir ticket interne 1848)
