### PR TITLE
Ajout d'un timer pour la mise à jour du log

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -55,6 +55,9 @@ def read_stdout_process(proc, id_job):
         realtime_output += proc.stdout.readline()
 
         if proc.poll() is not None:
+            # entre temps, des nouveaux messages sont peut-etre arrives
+            for line in proc.stdout.readlines():
+                realtime_output += line
             if len(realtime_output) > 0:
                 requests.post(URL_API +
                               'job/' +


### PR DESCRIPTION
# Motivation
Pour contribuer à limiter la saturation de l'API (#93 ), on propose d'ajouter un délai minimal à respecter dans le client pour envoyer des requêtes de mise à jour du log (par exemple 5s)