### PR TITLE
fix(monitor): Correction de l erreur sur la page du job lorsqu'on vide la base

### DIFF
--- a/monitor/views/pages/job.ejs
+++ b/monitor/views/pages/job.ejs
@@ -32,6 +32,7 @@
 
           <%- include ("../partials/menu/topbar") %>
 
+          <% if (locals.job) { %>
           <!-- Content Row -->
           <div class="row">
             <div class="col-lg-6 mb-4">
@@ -48,7 +49,7 @@
 
         </div>
         <!-- /.container-fluid -->
-
+        <% } %>
       </div>
       <!-- End of Main Content -->
 


### PR DESCRIPTION
# Motivation

Issue: #88 

Lorsqu'on demande à vider la base alors qu'on est sur la page d'un job, cela crée une erreur (puisque le job affiché n'existe plus).
