### PR TITLE
gestion des priorités sur les chantiers

### DIFF
--- a/api/doc/swagger.yml
+++ b/api/doc/swagger.yml
@@ -223,6 +223,33 @@ paths:
          description: OK
        '404':
          description: Not Found
+  '/project/{id}/setPriority':
+    post:
+     tags:
+       - projects
+     summary: "Changement de la priorité des jobs du projet"
+     parameters:
+        - in: path
+          name: id
+          description: l'identifiant du projet à modififier
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: priority
+          description: priority
+          required: true
+          schema:
+            type: string
+            enum:
+              - low
+              - normal
+              - high
+     responses:
+       '200':
+         description: OK
+       '404':
+         description: Not Found
   '/projects':
     get:
      tags:

--- a/api/middlewares/project.js
+++ b/api/middlewares/project.js
@@ -193,6 +193,27 @@ async function deleteProjects(req, res, next) {
   next();
 }
 
+async function setPriority(req, res, next) {
+  const params = matchedData(req);
+  const { id } = params;
+  const { priority } = params;
+  debug('id : ', id);
+  debug('priority : ', priority);
+  await req.client.query('UPDATE projects SET priority=$1 WHERE id=$2',
+    [priority, id])
+    .then((results) => {
+      req.result = results.rows;
+    })
+    .catch((error) => {
+      req.error = {
+        msg: error.toString(),
+        code: 404,
+        function: 'setPriority',
+      };
+    });
+  next();
+}
+
 module.exports = {
   insertProjectFromJson,
   getAllProjects,
@@ -200,4 +221,5 @@ module.exports = {
   getProjectStatus,
   deleteProject,
   deleteProjects,
+  setPriority,
 };

--- a/api/routes/projects/index.js
+++ b/api/routes/projects/index.js
@@ -1,5 +1,5 @@
 const router = require('express').Router();
-const { body, param } = require('express-validator/check');
+const { body, param, query } = require('express-validator/check');
 
 const validateParams = require('../../middlewares/validateParams');
 const createErrorMsg = require('../../middlewares/createErrorMsg');
@@ -55,6 +55,21 @@ router.get('/projects/status',
 router.delete('/projects/delete',
   pgClient.open,
   project.deleteProjects,
+  pgClient.close,
+  returnMsg);
+
+router.post('/project/:id/setPriority',
+  param('id')
+    .exists().withMessage(createErrorMsg.getMissingParameterMsg('id'))
+    .isInt({ min: 1 })
+    .withMessage(createErrorMsg.getInvalidParameterMsg('id')),
+  query('priority')
+    .exists().withMessage(createErrorMsg.getMissingParameterMsg('priority'))
+    .isIn(['low', 'normal', 'high'])
+    .withMessage(createErrorMsg.getInvalidParameterMsg('priority')),
+  validateParams,
+  pgClient.open,
+  project.setPriority,
   pgClient.close,
   returnMsg);
 

--- a/api/test/projects.js
+++ b/api/test/projects.js
@@ -105,6 +105,18 @@ describe('Projects', () => {
         });
     });
   });
+  describe('set project priority', () => {
+    it('should return an array', (done) => {
+      chai.request(server)
+        .post(`/api/project/${idProject}/setPriority`)
+        .query({ priority: 'high' })
+        .end((err, res) => {
+          should.equal(err, null);
+          res.should.have.status(200);
+          done();
+        });
+    });
+  });
   describe('Delete one project', () => {
     it('should return an array', (done) => {
       chai.request(server)

--- a/monitor/resources/vendor/ign/gpao.js
+++ b/monitor/resources/vendor/ign/gpao.js
@@ -15,6 +15,19 @@ function deleteProject(id, name) {
   }
 }
 
+// Fonction permettant de changer la priorité d'un projet
+function setPriority(id, priority) {
+  // on fait une requete sur l'API
+  fetch(`${apiUrl}/api/project/${id}/setPriority?priority=${priority}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then(() => {
+    location.reload();
+  });
+}
+
 // Fonction modifiant le nombre de thrad actif sur une machine
 function setNbThread(host, active) {
   value = window.prompt(`Modifier le nombre de Threads actifs pour ${host}, ${active}`, 0);

--- a/monitor/views/partials/tab/projects_tab.ejs
+++ b/monitor/views/partials/tab/projects_tab.ejs
@@ -10,6 +10,7 @@
               <th>Id</th>
               <th>Name</th>
               <th>Status</th>
+              <th>Priority</th>
               <th>Action</th>
             </tr>
         </thead>
@@ -18,6 +19,7 @@
               <th>Id</th>
               <th>Name</th>
               <th>Status</th>
+              <th>Priority</th>
               <th>Action</th>
             </tr>
         </tfoot>
@@ -27,8 +29,21 @@
                     <td> <%= project.id %></td>
                     <td> <%= project.name %></td>
                     <td> <%= project.status %></td>
+                    <td> <div class="dropdown">
+                      <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <%= project.priority %>
+                      </button>
+                      <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                        <a class="dropdown-item" href="javascript:setPriority(<%= project.id %>, 'low')">Low</a>
+                        <a class="dropdown-item" href="javascript:setPriority(<%= project.id %>, 'normal')">Normal</a>
+                        <a class="dropdown-item" href="javascript:setPriority(<%= project.id %>, 'high')">High</a>
+                      </div>
+                    </div>
+                  </td>
                     <td>
-                        <button type="button" onclick='deleteProject("<%= project.id %>", "<%= project.name %>")' data-toggle="tooltip" title="Supprime le projet de la base" class="btn btn-circle btn-danger"><i class="fas fa-trash fa-1x" aria-hidden="true"></i></button>
+                        <button type="button" onclick='deleteProject("<%= project.id %>", "<%= project.name %>")' 
+                          data-toggle="tooltip" title="Supprime le projet de la base" 
+                          class="btn btn-circle btn-danger"><i class="fas fa-trash fa-1x" aria-hidden="true"></i></button>
                     </td>
                 </tr>
                 <% }) %>


### PR DESCRIPTION
# Motivation
Ajout d'une gestion des priorités sur les projets.

# Principe

- ajout d'un enum appelé priority sur la table projects (low, normal, high)
- par défaut, tous les projets créés sont classés en normal
- ajout d'une route setPriority pour modifier la priorité d'un projet
- ajout d'un colonne priorité dans l'affichage des projets sur le monitor avec la possibilité de la modifier
- création d'une fonction pour l'attribution d'un job (à la place de la requête SQL un peu complexe présente dans l'API), ajout d'une jointure avec les projets dans cette requête et classement (d'abord sur le priorité du projet, puis sur l'Id du job)
