### PR TITLE
fix(monitor): correction pour la page des jobs avec les \/

### DIFF
--- a/monitor/middlewares/job.js
+++ b/monitor/middlewares/job.js
@@ -8,6 +8,7 @@ async function getJobs(req, res, next) {
   /* eslint-disable no-param-reassign */
   jobs.forEach((element) => {
     element.job_log = '';
+    element.job_command = '';
   });
   /* eslint-enable no-param-reassign */
 


### PR DESCRIPTION
# motivation

Lorsqu'il y a des \\ dans les lignes de commandes la page des jobs du monitor n'affiche plus rien

# principe

On n'a pas besoin des lignes de commande (pas affiché dans le tableau des jobs), donc on peut les supprimer (comme c'est déjà le cas pour les logs).